### PR TITLE
Allow object in multipart/form-data body

### DIFF
--- a/connexion/decorators/validation.py
+++ b/connexion/decorators/validation.py
@@ -166,6 +166,12 @@ class RequestBodyValidator:
                 if data is not None or not self.has_default:
                     self.validate_schema(data, request.url)
             elif self.consumes[0] in FORM_CONTENT_TYPES:
+                # Convert multipart object items into dictionaries
+                for k, v in request.form.items():
+                    if (k in self.schema.get('properties', {}).keys() and
+                            self.schema['properties'][k]['type'] == 'object'):
+                        request.form[k] = json.loads(v) if v else {}
+
                 data = dict(request.form.items()) or (request.body if len(request.body) > 0 else {})
                 data.update(dict.fromkeys(request.files, ''))  # validator expects string..
                 logger.debug('%s validating schema...', request.url)


### PR DESCRIPTION
Hi there,
when you define a multipart request, having both an object and a file upload, i.e. e.g., 
```yaml
requestBody:
  content: 
    multipart/form-data: # Media type
      schema:            # Request payload
        type: object
        properties:      # Request parts
          id:            # Part 1 (string value)
            type: string
            format: uuid
          address:       # Part2 (object)
            type: object
            properties:
              street:
                type: string
              city:
                type: string
          profileImage:  # Part 3 (an image)
            type: string
            format: binary
```
(cf. https://swagger.io/docs/specification/describing-request-body/multipart-requests/)
you will get validation errors.

Changes proposed in this pull request:

 - Convert the request body into the correct data type
   - Altering the request.form is not very clean but if you are not doing this, the parameter validation fails and if you circumvent that validation, it won't appear in the `body`.
 
